### PR TITLE
support for latex based on vimtex plugin regex

### DIFF
--- a/after/ftplugin/tex.vim
+++ b/after/ftplugin/tex.vim
@@ -1,2 +1,2 @@
-" Function/augroup definition
+" Beginning of a section
 call jumpy#map('\v\s*\\%(%(sub)*section|chapter|part|appendix|%(front|back|main)matter)>')

--- a/after/ftplugin/tex.vim
+++ b/after/ftplugin/tex.vim
@@ -1,0 +1,2 @@
+" Function/augroup definition
+call jumpy#map('\v\s*\\%(%(sub)*section|chapter|part|appendix|%(front|back|main)matter)>')

--- a/autoload/jumpy_test.vim
+++ b/autoload/jumpy_test.vim
@@ -12,6 +12,7 @@ fun! Test_jumpy() abort
 		\ 'test.rb':       [2, 5, 6, 7],
 		\ 'test.sh':       [2, 5],
 		\ 'test.sql':      [2, 5, 7],
+		\ 'test.tex':      [3, 5, 6, 8, 10, 11, 12, 14, 16],
 		\ 'test.vim':      [2, 6],
 		\ 'test.yaml':     [2, 5],
 	\ }

--- a/autoload/testdata/test.tex
+++ b/autoload/testdata/test.tex
@@ -1,0 +1,20 @@
+\begin{document}
+
+  \frontmatter
+
+  \mainmatter
+  \part{foo}
+
+  \chapter{bar}
+
+  \section{baz}
+    \subsection{boz}
+      \subsubsection{zab}
+
+  \appendix
+
+  \backmatter
+
+\end{document}
+
+


### PR DESCRIPTION
Hi,

Good idea for this plugin !

I simply ported the regex that [vimtex](https://github.com/lervag/vimtex/) uses for `]]`-like mappings. See [motion.vim](https://github.com/lervag/vimtex/blob/master/autoload/vimtex/motion.vim).

<sub><sup>note that the lua test file is named `a.lua` which breaks the tests</sup></sub>