### PR TITLE
Add support for ft=qf

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,6 +29,7 @@ Currently supported filetype with their patterns:
     markdown     Header and horizontal rule          \v%(^\=\=\=|^---|^#{1,6})
     php          Function, class, interface          \v^\s*%(%(abstract\s+|final\s+|private\s+|public\s+|protected\s|static\s+)*function|%(abstract\s+|final\s+)*class|interface)>
     python       Function, method, class             \v^(class|\s*def|\s*async def)>
+    qf           Beginning of file chunk             \v^([^\|]+).*\n\1@!\zs
     ruby         Function, class, or module          \v^\s*%(def|class|module)>
     sh           Function declaration                ^\w\+()[ \n]*{
     sql          CREATE and BEGIN                    \c\v^\s*%(create|begin)>

--- a/README.markdown
+++ b/README.markdown
@@ -29,7 +29,7 @@ Currently supported filetype with their patterns:
     markdown     Header and horizontal rule          \v%(^\=\=\=|^---|^#{1,6})
     php          Function, class, interface          \v^\s*%(%(abstract\s+|final\s+|private\s+|public\s+|protected\s|static\s+)*function|%(abstract\s+|final\s+)*class|interface)>
     python       Function, method, class             \v^(class|\s*def|\s*async def)>
-    qf           Beginning of file chunk             \%#=1\v^([^\|]+).*\n\1@!\zs
+    qf           Next/prev filename                  \%#=1\v^([^\|]+).*\n\1@!\zs
     ruby         Function, class, or module          \v^\s*%(def|class|module)>
     sh           Function declaration                ^\w\+()[ \n]*{
     sql          CREATE and BEGIN                    \c\v^\s*%(create|begin)>

--- a/README.markdown
+++ b/README.markdown
@@ -29,7 +29,7 @@ Currently supported filetype with their patterns:
     markdown     Header and horizontal rule          \v%(^\=\=\=|^---|^#{1,6})
     php          Function, class, interface          \v^\s*%(%(abstract\s+|final\s+|private\s+|public\s+|protected\s|static\s+)*function|%(abstract\s+|final\s+)*class|interface)>
     python       Function, method, class             \v^(class|\s*def|\s*async def)>
-    qf           Beginning of file chunk             \v^([^\|]+).*\n\1@!\zs
+    qf           Beginning of file chunk             \%#=1\v^([^\|]+).*\n\1@!\zs
     ruby         Function, class, or module          \v^\s*%(def|class|module)>
     sh           Function declaration                ^\w\+()[ \n]*{
     sql          CREATE and BEGIN                    \c\v^\s*%(create|begin)>

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -1,2 +1,2 @@
-" Beginning of file chunk
+" Next/prev filename
 call jumpy#map('\%#=1\v^([^\|]+).*\n\1@!\zs')

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -1,2 +1,2 @@
 " Beginning of file chunk
-call jumpy#map('\v^([^\|]+).*\n\1@!\zs')
+call jumpy#map('\%#=1\v^([^\|]+).*\n\1@!\zs')

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -1,0 +1,2 @@
+" Beginning of file chunk
+call jumpy#map('\v^([^\|]+).*\n\1@!\zs')

--- a/autoload/jumpy_test.vim
+++ b/autoload/jumpy_test.vim
@@ -12,7 +12,7 @@ fun! Test_jumpy() abort
 		\ 'test.markdown': [4, 5, 9],
 		\ 'test.php':      [4, 5, 8, 11, 15, 18, 20],
 		\ 'test.py':       [2, 4, 5, 8, 9],
-		\ 'test.qf':       [1, 8, 9, 12, 13, 14],
+		\ 'test.qf':       [2, 3, 6, 7, 8],
 		\ 'test.rb':       [2, 5, 6, 7],
 		\ 'test.sh':       [2, 5],
 		\ 'test.sql':      [2, 5, 7],
@@ -27,12 +27,14 @@ fun! Test_jumpy() abort
 			return Errorf('unable to read "%s"', l:file)
 		endif
 		exe 'e ' . l:file
+		if &filetype is# ''
+			let &filetype=fnamemodify(l:file, ':e')
+		endif
 
 		" Should jump to last line if there are no more matches (also tests if
 		" there are no matches after wantlines).
 		" This is why test files should end with a blank line!
 		let l:wantlines = add(l:wantlines, line('$'))
-
 		normal! gg
 		for l:want in l:wantlines
 			" vint: -ProhibitCommandRelyOnUser

--- a/autoload/jumpy_test.vim
+++ b/autoload/jumpy_test.vim
@@ -12,6 +12,7 @@ fun! Test_jumpy() abort
 		\ 'test.markdown': [4, 5, 9],
 		\ 'test.php':      [4, 5, 8, 11, 15, 18, 20],
 		\ 'test.py':       [2, 4, 5, 8, 9],
+		\ 'test.qf':       [1, 8, 9, 12, 13, 14],
 		\ 'test.rb':       [2, 5, 6, 7],
 		\ 'test.sh':       [2, 5],
 		\ 'test.sql':      [2, 5, 7],

--- a/autoload/testdata/test.qf
+++ b/autoload/testdata/test.qf
@@ -1,0 +1,18 @@
+foo.txt|1 col 6| error
+foo.txt|12 col 26| error
+foo.txt|30 col 27| error
+foo.txt|4 col 2| error
+foo.txt|5 col 26| error
+foo.txt|1 col 26| error
+bar.txt|3 col 242| error
+baz.txt|242 col 1| error
+baz.txt|242 col 1| error
+baz.txt|242 col 1| error
+boz.txt|242 col 1| error
+biz.txt|242 col 1| error
+buz.txt|242 col 1| error
+buz.txt|242 col 1| error
+buz.txt|242 col 1| error
+buz.txt|242 col 1| error
+
+

--- a/autoload/testdata/test.qf
+++ b/autoload/testdata/test.qf
@@ -1,9 +1,4 @@
 foo.txt|1 col 6| error
-foo.txt|12 col 26| error
-foo.txt|30 col 27| error
-foo.txt|4 col 2| error
-foo.txt|5 col 26| error
-foo.txt|1 col 26| error
 bar.txt|3 col 242| error
 baz.txt|242 col 1| error
 baz.txt|242 col 1| error
@@ -14,5 +9,4 @@ buz.txt|242 col 1| error
 buz.txt|242 col 1| error
 buz.txt|242 col 1| error
 buz.txt|242 col 1| error
-
 


### PR DESCRIPTION
Here we are...

I tried `\%#=1` for old regex engine and it actually does help for thousands of lines.

For the comment, how about something like "First error in the next/current file" inspired from `:h :cnf` ?