### PR TITLE
Update ft=vim regex

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,7 +34,7 @@ Currently supported filetype with their patterns:
     sh           Function declaration                ^\w\+()[ \n]*{
     sql          CREATE and BEGIN                    \c\v^\s*%(create|begin)>
     tex          Beginning of a section              \v\s*\\%(%(sub)*section|chapter|part|appendix|%(front|back|main)matter)>
-    vim          Function/augroup definition         \v%(^\s*fu%[nction]>|aug%[roup] (end)@!)
+    vim          Function/augroup definition         \v^\s*%(fu%[nction]>|aug%[roup]\s%(\s*[eE][nN][dD])@!)
     yaml         Top-level key                       ^\w\+:
 
 This overrides mappings for some filetypes in Vim's standard distribution for

--- a/after/ftplugin/vim.vim
+++ b/after/ftplugin/vim.vim
@@ -1,2 +1,2 @@
 " Function/augroup definition
-call jumpy#map('\v%(^\s*fu%[nction]>|aug%[roup] (end)@!)')
+call jumpy#map('\v^\s*%(fu%[nction]>|aug%[roup]\s%(\s*[eE][nN][dD])@!)')

--- a/autoload/jumpy_test.vim
+++ b/autoload/jumpy_test.vim
@@ -17,7 +17,7 @@ fun! Test_jumpy() abort
 		\ 'test.sh':       [2, 5],
 		\ 'test.sql':      [2, 5, 7],
 		\ 'test.tex':      [3, 5, 6, 8, 10, 11, 12, 14, 16],
-		\ 'test.vim':      [2, 6],
+		\ 'test.vim':      [2, 6, 16, 21, 26],
 		\ 'test.yaml':     [2, 5],
 	\ }
 

--- a/autoload/testdata/test.vim
+++ b/autoload/testdata/test.vim
@@ -8,4 +8,24 @@ augroup asd
 	au asd
 augroup end
 
+" augroup commented
+" 	au!
+" 	au comment
+" augroup END
+
+aug uppercase
+	au!
+	au end
+aug END
+
+augr mixed
+	au!
+	au mixed
+augroup End
+
+augro spaced
+	au!
+	au end
+augroup       END
+
 


### PR DESCRIPTION
`\v^\s*%(fu%[nction]>|aug%[roup]\s%(\s*[eE][nN][dD])@!)`

  * commented `augroup` won't match anymore.
  * any valid `augroup end` won't match either. This includes if `ignorecase` is off and if there are multiple whitespaces before `end`.