### PR TITLE
Fix Markdown regex

### DIFF
--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -1,3 +1,3 @@
 " Header and horizontal rule
 "
-call jumpy#map('\v%(^\=\=\=|^---|^#{1,6}|^\*\*\*|^___)', '')
+call jumpy#map('\v%(^\=\=\=|^---|^#{1,6}[^#]|^\*\*\*|^___)', '')

--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -1,3 +1,3 @@
 " Header and horizontal rule
 "
-call jumpy#map('\v%(^\=\=\=|^---|^#{1,6})', '')
+call jumpy#map('\v%(^\=\=\=|^---|^#{1,6}|^\*\*\*|^___)', '')

--- a/autoload/jumpy_test.vim
+++ b/autoload/jumpy_test.vim
@@ -12,7 +12,7 @@ fun! Test_jumpy_section() abort
 		\ 'test.html':     [2, 4, 8],
 		\ 'test.js':       [3, 5, 9, 11],
 		\ 'test.lua':      [2, 5],
-		\ 'test.markdown': [4, 5, 9],
+		\ 'test.markdown': [4, 5, 9, 10, 11, 12],
 		\ 'test.php':      [4, 5, 8, 11, 15, 18, 20],
 		\ 'test.py':       [2, 4, 5, 8, 9],
 		\ 'test.qf':       [2, 3, 6, 7, 8],

--- a/autoload/testdata/test.markdown
+++ b/autoload/testdata/test.markdown
@@ -6,6 +6,17 @@ Much text!
 
 .id { }
 
+===
 ---
+***
+___
+
+==
+
+a #tag in the #body-text
+
+--
+
+*
 
 

--- a/autoload/testdata/test.markdown
+++ b/autoload/testdata/test.markdown
@@ -19,4 +19,9 @@ a #tag in the #body-text
 
 *
 
+A line with nothing but hashes
+###
+
+####### Too many hashes
+
 


### PR DESCRIPTION
The goal of this PR is to add support for `***` as a way of writing the hrule, so it adds both that and `===` as alternatives in the regex.

But I also noticed when I did that that the part of the regex that detects the section header was `^#{1,6}`, which can't be right.
* If the intention was to only allow heading levels up to 6 like in the spec, the behavior would be incorrect because it didn't actually reject greater numbers of hashes. I assumed this and added `[^#]` afterwards, which has the (probably desirable) side-effect of rejecting "headings" with no text.
* If the current behavior is intended, it's redundant, and can just be replaced with `^#`.